### PR TITLE
look for gaps excluding current date

### DIFF
--- a/macros/tests/sequence_gaps.sql
+++ b/macros/tests/sequence_gaps.sql
@@ -19,6 +19,8 @@
             ) AS {{ previous_column }}
         FROM
             {{ table }}
+        WHERE
+            block_timestamp::date <= current_date - 1
     )
 SELECT
     {{ partition_sql + "," if partition_sql }}


### PR DESCRIPTION
- Gaps tests are failing for current date when the test is run due to how data comes in where it is not guaranteed to come in by contiguous blocks.  I have verified over the last few days that the "gaps" resolve themselves on the next incremental as the data is actually there in the chainwalkers database.