### PR TITLE
grab balances needed per day

### DIFF
--- a/models/silver/silver__all_unknown_balances.sql
+++ b/models/silver/silver__all_unknown_balances.sql
@@ -19,6 +19,7 @@ WITH all_wallets AS (
 wallets_per_block AS (
     SELECT
         DISTINCT block_id,
+        block_timestamp :: DATE AS block_timestamp_date,
         attribute_value AS address
     FROM
         {{ ref('silver__msg_attributes') }}
@@ -28,6 +29,24 @@ wallets_per_block AS (
             'osmo\\w{39}'
         )
         AND block_id > 2383300
+),
+max_block_id_per_date AS (
+    SELECT
+        block_timestamp_date,
+        MAX(block_id) AS max_block_id
+    FROM
+        wallets_per_block
+    GROUP BY
+        1
+),
+unique_address_per_block_date AS (
+    SELECT
+        DISTINCT max_block_id,
+        address
+    FROM
+        wallets_per_block b
+        LEFT OUTER JOIN max_block_id_per_date d
+        ON d.block_timestamp_date = b.block_timestamp_date
 ),
 possible_balances_needed AS (
     SELECT
@@ -39,7 +58,7 @@ possible_balances_needed AS (
     SELECT
         *
     FROM
-        wallets_per_block
+        unique_address_per_block_date
 )
 SELECT
     block_id,
@@ -51,7 +70,10 @@ SELECT
     DISTINCT block_id,
     address
 FROM
-    {{ source('osmosis_external','balances_api') }}
+    {{ source(
+        'osmosis_external',
+        'balances_api'
+    ) }}
 ORDER BY
     block_id
 LIMIT


### PR DESCRIPTION
- optimizing query to output unique addresses per day.  This will greatly reduce the number of calls needed to backfill the data and moving forward and still give us daily balances granularity