### PR TITLE
adds cluster_by keys for reference models from streamline queries

### DIFF
--- a/models/silver/silver__liquidity_provider_actions.sql
+++ b/models/silver/silver__liquidity_provider_actions.sql
@@ -2,7 +2,8 @@
     materialized = 'incremental',
     unique_key = "_unique_key",
     incremental_strategy = 'merge',
-    cluster_by = ['block_timestamp::DATE','block_id::NUMBER'],
+    cluster_by = ['block_timestamp::DATE'],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION equality(block_id)"
 ) }}
 
 WITH

--- a/models/silver/silver__liquidity_provider_actions.sql
+++ b/models/silver/silver__liquidity_provider_actions.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = "_unique_key",
     incremental_strategy = 'merge',
-    cluster_by = ['block_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','block_id::NUMBER'],
 ) }}
 
 WITH

--- a/models/silver/silver__msg_attributes.sql
+++ b/models/silver/silver__msg_attributes.sql
@@ -2,8 +2,8 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE','block_id::NUMBER'],
-  post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION"
+  cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
+  post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION" | "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON equality(block_id)" 
 ) }}
 
 SELECT

--- a/models/silver/silver__msg_attributes.sql
+++ b/models/silver/silver__msg_attributes.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = "_unique_key",
   incremental_strategy = 'merge',
-  cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
+  cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE','block_id::NUMBER'],
   post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION"
 ) }}
 


### PR DESCRIPTION
- Adds `block_id` to `cluster_by` for tables referenced from `streamline` pull queries that need to implement `order by`