### PR TITLE
Hotfix/transfers incremental

### DIFF
--- a/.github/workflows/dbt_run_incremental.yml
+++ b/.github/workflows/dbt_run_incremental.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       dbt_command: |
           dbt run-operation stage_external_sources --vars "ext_full_refresh: true"
-          dbt run -s ./models --exclude models/silver/_observability  tag:balances  tag:daily
+          dbt run -s ./models --exclude models/silver/_observability  tag:balances  tag:daily models/silver/core/silver__transfers.sql+
           dbt run-operation stage_external_sources --vars "ext_full_refresh: true"
       environment: workflow_prod
       warehouse: ${{ vars.WAREHOUSE }}

--- a/.github/workflows/dbt_run_incremental.yml
+++ b/.github/workflows/dbt_run_incremental.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       dbt_command: |
           dbt run-operation stage_external_sources --vars "ext_full_refresh: true"
-          dbt run -s ./models --exclude models/silver/_observability  tag:balances  tag:daily models/silver/core/silver__transfers.sql+
+          dbt run -s ./models --exclude models/silver/_observability  tag:balances  tag:daily
           dbt run-operation stage_external_sources --vars "ext_full_refresh: true"
       environment: workflow_prod
       warehouse: ${{ vars.WAREHOUSE }}


### PR DESCRIPTION
- Materialize `base_att` as a temp table before referencing in CTE
  - Something with how the CTE is represented in memory within snowflake is causing long model incremental run times when filtering it using WHERE clauses. Materializing it as a temp table appears to fix the issue
- Remove unnecessary join
- Re-enable transfers incremental load