### PR TITLE
An 5083 -- fix github asset metadata, which is introducing dupes

### DIFF
--- a/models/bronze/bronze_api/bronze_api__github_asset_metadata.sql
+++ b/models/bronze/bronze_api/bronze_api__github_asset_metadata.sql
@@ -6,7 +6,7 @@
 SELECT
   live.udf_api(
     'GET',
-    'https://github.com/osmosis-labs/assetlists/blob/main/osmosis-1/generated/chain_registry/assetlist.json',{},{}
+    'https://raw.githubusercontent.com/osmosis-labs/assetlists/main/osmosis-1/generated/chain_registry/assetlist.json',{},{}
   ) AS resp,
   SYSDATE() AS _inserted_timestamp,
   '{{ invocation_id }}' AS _invocation_id

--- a/models/bronze/bronze_api/bronze_api__github_asset_metadata.sql
+++ b/models/bronze/bronze_api/bronze_api__github_asset_metadata.sql
@@ -6,7 +6,7 @@
 SELECT
   live.udf_api(
     'GET',
-    'https://raw.githubusercontent.com/osmosis-labs/assetlists/main/osmosis-1/osmosis-1.assetlist.json',{},{}
+    'https://github.com/osmosis-labs/assetlists/blob/main/osmosis-1/generated/chain_registry/assetlist.json',{},{}
   ) AS resp,
   SYSDATE() AS _inserted_timestamp,
   '{{ invocation_id }}' AS _invocation_id

--- a/models/silver/core/silver__asset_metadata.sql
+++ b/models/silver/core/silver__asset_metadata.sql
@@ -34,7 +34,7 @@ combo AS (
     raw_metadata,
     COALESCE(
       raw_metadata [0] :aliases [0] :: STRING,
-      raw_metadata [0] :denom :: STRING
+      raw_metadata [0] :denom [0] :: STRING
     ) AS denom,
     address AS _unique_key,
     _inserted_timestamp

--- a/models/silver/core/silver__asset_metadata.sql
+++ b/models/silver/core/silver__asset_metadata.sql
@@ -43,17 +43,17 @@ combo AS (
   UNION ALL
   SELECT
     COALESCE(
-      VALUE :denom :: STRING,
+      VALUE :denom [0] :: STRING,
       base
     ) AS address,
     NAME AS label,
     symbol AS project_name,
-    VALUE :aliases :: STRING AS alias,
-    VALUE :exponent :: INT AS DECIMAL,
+    VALUE :aliases [0] :: STRING AS alias,
+    VALUE :exponent [0] :: INT AS DECIMAL,
     denom_units AS raw_metadata,
     COALESCE(
       VALUE :aliases [0] :: STRING,
-      VALUE :denom :: STRING
+      VALUE :denom [0] :: STRING
     ) AS denom,
     address AS _unique_key,
     _inserted_timestamp

--- a/models/silver/core/silver__asset_metadata.sql
+++ b/models/silver/core/silver__asset_metadata.sql
@@ -34,7 +34,7 @@ combo AS (
     raw_metadata,
     COALESCE(
       raw_metadata [0] :aliases [0] :: STRING,
-      raw_metadata [0] :denom [0] :: STRING
+      raw_metadata [0] :denom :: STRING
     ) AS denom,
     address AS _unique_key,
     _inserted_timestamp
@@ -43,17 +43,17 @@ combo AS (
   UNION ALL
   SELECT
     COALESCE(
-      VALUE :denom [0] :: STRING,
+      VALUE :denom :: STRING,
       base
     ) AS address,
     NAME AS label,
     symbol AS project_name,
-    VALUE :aliases [0] :: STRING AS alias,
-    VALUE :exponent [0] :: INT AS DECIMAL,
+    VALUE :aliases :: STRING AS alias,
+    VALUE :exponent :: INT AS DECIMAL,
     denom_units AS raw_metadata,
     COALESCE(
       VALUE :aliases [0] :: STRING,
-      VALUE :denom [0] :: STRING
+      VALUE :denom :: STRING
     ) AS denom,
     address AS _unique_key,
     _inserted_timestamp


### PR DESCRIPTION
### 1. Fix token registry path (`bronze_api__github_asset_metadata`)
Osmosis Labs publishes a token registry ([json](https://raw.githubusercontent.com/osmosis-labs/assetlists/main/osmosis-1/generated/chain_registry/assetlist.json)) through Github. **At some point, the location of this registry changed; this has been corrected.**

### 2. Limit extraction from token registry (`silver__asset_metadata`)
I cannot be certain, but at some point in the past it's possible that Osmosis Labs only shared one contract and denomination pair (USDC) per token. But now, it appears that they publish two, the second coming from the [Token Factory](https://docs.osmosis.zone/osmosis-core/modules/tokenfactory/) module. These contracts are denominated in the native asset, and you can see an example of both for `WIHA` [here](https://coinmarketcap.com/dexscan/osmosis/1793/) (see Contracts section).

You can also see this in `silver__github_asset_metadata` with this query:
```sql
select * from osmosis_dev.silver.github_asset_metadata where display = 'WIHA';
```
result set:
```js
[
  {
    "denom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/wiha",
    "exponent": 0
  },
  {
    "denom": "WIHA",
    "exponent": 6
  }
]
```

This creates dupes in `silver__asset_metadata` as seen here:
```sql
select * from osmosis.silver.asset_metadata where project_name = 'WIHA';
```
**As such, the union all between bronze and existing silver tables are limited to the first list item ([0]) in each json base/denom attribute.** 

This is likely why there are situations downstream, like Blockaid reported in `core__dim_prices`, where prices ~1.0. They're being calculated as WIHA/WIHA:
```sql
select * from osmosis.price.dim_prices where symbol = 'WIHA' limit 1;
```
### 3. For further consideration
It's interesting that `price__ez_prices` filters out swap prices ([line 33](https://github.com/FlipsideCrypto/osmosis-models/blob/5b899cc5d76a45a35cd89285d1bec8ddb67d6e08/models/gold/price/price__ez_prices.sql#L33)), as those are actually the correct prices as reported in Coin Market Cap and other sources. We have the correct data from swaps, but are not using them:
```sql
select * from osmosis.price.dim_prices where symbol = 'WIHA' and recorded_at = '2024-07-02 15:00:00.000' limit 2;
```

One quick solution for Blockaid is to rely on `price__dim_prices` instead of `price__ez_prices`, filtering to `where provider = 'swaps'`.